### PR TITLE
chore(date-fns): 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
-    "@date-io/date-fns": "^1.3.13",
+    "@date-io/date-fns": "^2.8.1",
     "@material-ui/core": "^4.11.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,17 +2470,22 @@
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
 
-"@date-io/core@1.x", "@date-io/core@^1.3.13":
+"@date-io/core@1.x":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/date-fns@^1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-1.3.13.tgz#7798844041640ab393f7e21a7769a65d672f4735"
-  integrity sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==
+"@date-io/core@^2.8.1":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.9.0.tgz#5f36e259b6438e456ca0fc177b57f68772b4b7b2"
+  integrity sha512-OhPFn+mnVHzfF/zJNUTV1CeUCL51ngXo9sG458cwwsORTgc1Pw7Dx9dS1wqPsq+CcMQ5Sh1MsUIXi1zclFbHTQ==
+
+"@date-io/date-fns@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.8.1.tgz#38bccab061b8183304679c6fcb5f92fc262280a3"
+  integrity sha512-GZS49pCUeN7ztiXARfthj0/FLjcDKA7wFff8PlaXevngx0akU+Epnv6TGDCflaA2Vbx87gVUkUvpDf3JAI2eDw==
   dependencies:
-    "@date-io/core" "^1.3.13"
+    "@date-io/core" "^2.8.1"
 
 "@emotion/cache@^10.0.17", "@emotion/cache@^10.0.9":
   version "10.0.19"


### PR DESCRIPTION
Cannot upgrade [until @material-ui/pickers v4](https://github.com/mui-org/material-ui-pickers/issues/1440#issuecomment-607133842)

Note: We will also need to update `date-fns` in mson